### PR TITLE
Can launch without running the shellscript

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,10 @@ Nvidia Jeston TX2/Xavier/XavierNX have CAN controller(s) integrated in the main 
     # receiving data from can0
     $ candump can0
     ```
-**Alternatives:**
-1. Add into bunker_robot_base.launch:
+---------------------------------------------------------------------------------
+
+**Alternatives to 3:**
+1) Add into bunker_robot_base.launch:
 ```
 <node name="setup_can_interface" pkg="bunker_bringup" type="bringup_can2usb.bash" output="screen" />
 ```
@@ -96,8 +98,8 @@ Nvidia Jeston TX2/Xavier/XavierNX have CAN controller(s) integrated in the main 
     <username> ALL=(ALL) NOPASSWD: /sbin/modprobe, /sbin/ip link set can0 up type can bitrate 500000
   ```
 OR
-2. 
-Run the shellscript:
+
+2) Run the shellscript:
 ```
 $ sudo ./bunker_pro.sh
 ```
@@ -108,7 +110,8 @@ source /opt/ros/noetic/setup.bash
 # Replace '/home/ara/bunker_ws' with your actual ROS ws path.
 source /home/ara/bunker_ws/devel/setup.bash
 ```
-  
+---------------------------------------------------------------------------------
+
 4. Launch ROS nodes
 
 * Start the base node for the real robot

--- a/README.md
+++ b/README.md
@@ -82,6 +82,11 @@ Nvidia Jeston TX2/Xavier/XavierNX have CAN controller(s) integrated in the main 
     # receiving data from can0
     $ candump can0
     ```
+**Alternatives:**
+1. Add into bunker_robot_base.launch:
+```
+<node name="setup_can_interface" pkg="bunker_bringup" type="bringup_can2usb.bash" output="screen" />
+```
 * The ROS environment is set up to handle password prompts, or configure sudo to allow these commands to execute without a password. This can be done by editing the sudoers file (using sudo visudo) like so:
   ```
     $ sudo visudo
@@ -90,6 +95,19 @@ Nvidia Jeston TX2/Xavier/XavierNX have CAN controller(s) integrated in the main 
   ```
     <username> ALL=(ALL) NOPASSWD: /sbin/modprobe, /sbin/ip link set can0 up type can bitrate 500000
   ```
+OR
+2. 
+Run the shellscript:
+```
+$ sudo ./bunker_pro.sh
+```
+*Note*: modify bunker_pro.sh:
+```
+# Replace '/opt/ros/noetic' with your actual ROS distribution path.
+source /opt/ros/noetic/setup.bash
+# Replace '/home/ara/bunker_ws' with your actual ROS ws path.
+source /home/ara/bunker_ws/devel/setup.bash
+```
   
 4. Launch ROS nodes
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,15 @@ Nvidia Jeston TX2/Xavier/XavierNX have CAN controller(s) integrated in the main 
     # receiving data from can0
     $ candump can0
     ```
-
+* The ROS environment is set up to handle password prompts, or configure sudo to allow these commands to execute without a password. This can be done by editing the sudoers file (using sudo visudo) like so:
+  ```
+    $ sudo visudo
+  ```
+* And adding a line for specific commands to be run without a password:
+  ```
+    <username> ALL=(ALL) NOPASSWD: /sbin/modprobe, /sbin/ip link set can0 up type can bitrate 500000
+  ```
+  
 4. Launch ROS nodes
 
 * Start the base node for the real robot

--- a/bunker_bringup/launch/bunker_robot_base.launch
+++ b/bunker_bringup/launch/bunker_robot_base.launch
@@ -8,6 +8,8 @@
     <arg name="is_bunker_mini" default="false" />
     <arg name="pub_tf" default="true" />
 
+    <node name="setup_can_interface" pkg="bunker_bringup" type="bringup_can2usb.bash" output="screen" />
+
     <include file="$(find bunker_base)/launch/bunker_base.launch">
         <arg name="port_name" default="$(arg port_name)" />
         <arg name="simulated_robot" default="$(arg simulated_robot)" />

--- a/bunker_bringup/scripts/bunker_pro.sh
+++ b/bunker_bringup/scripts/bunker_pro.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# Check for root permissions
+if [ "$(id -u)" != "0" ]; then
+    echo "This script must be run as root" >&2
+    exit 1
+fi
+
+# Source the ROS environment
+# Replace '/opt/ros/melodic' with your actual ROS distribution path.
+source /opt/ros/noetic/setup.bash
+source /home/ara/bunker_ws/devel/setup.bash
+
+# Load the gs_usb kernel module if not already loaded
+if ! lsmod | grep -q gs_usb; then
+    echo "Loading gs_usb module..."
+    sudo modprobe gs_usb
+else
+    echo "gs_usb module already loaded."
+fi
+
+# Set up the can0 device with a specified bitrate if not already set
+# Check if can0 is already up with the correct settings
+current_bitrate=$(ip -details link show can0 | grep -oP 'bitrate \K[^ ]+' || echo "down")
+
+if [[ $current_bitrate != "500000" ]]; then
+    echo "Setting up CAN0 interface..."
+    sudo ip link set can0 up type can bitrate 500000
+    if [ $? -eq 0 ]; then
+        echo "CAN0 interface setup successful."
+    else
+        echo "Failed to set up CAN0 interface." >&2
+        exit 2
+    fi
+else
+    echo "CAN0 interface already set up with correct bitrate."
+fi
+
+# Launch the ROS nodes
+echo "Launching ROS nodes..."
+roslaunch bunker_bringup bunker_robot_base.launch

--- a/bunker_bringup/scripts/bunker_pro.sh
+++ b/bunker_bringup/scripts/bunker_pro.sh
@@ -7,8 +7,9 @@ if [ "$(id -u)" != "0" ]; then
 fi
 
 # Source the ROS environment
-# Replace '/opt/ros/melodic' with your actual ROS distribution path.
+# Replace '/opt/ros/noetic' with your actual ROS distribution path.
 source /opt/ros/noetic/setup.bash
+# Replace '/home/ara/bunker_ws' with your actual ROS ws path.
 source /home/ara/bunker_ws/devel/setup.bash
 
 # Load the gs_usb kernel module if not already loaded


### PR DESCRIPTION
Basically add in this line to bunker_robot_base.launch:
```
<node name="setup_can_interface" pkg="bunker_bringup" type="bringup_can2usb.bash" output="screen" />
```

since bringup_can2usb.bash has a sudo, you also need to modify sudoers file using 
```
$ sudo visudo 
```
and adding in 
```
<username> ALL=(ALL) NOPASSWD: /sbin/modprobe, /sbin/ip link set can0 up type can bitrate 500000
```
